### PR TITLE
Update to wowza 4.4.0 and add nvidia support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM sameersbn/ubuntu:14.04.20160218
+FROM nvidia/cuda
 MAINTAINER sameer@damagehead.com
 
-ENV WOWZA_VERSION=4.3.0 \
+ENV WOWZA_VERSION=4.4.0 \
     WOWZA_DATA_DIR=/var/lib/wowza \
     WOWZA_LOG_DIR=/var/log/wowza
 


### PR DESCRIPTION
Updated to wowza 4.4.0 and changed source to nvidia/cuda to add support for nvidia GPU NVENC in transcoder presets
